### PR TITLE
Use a network socket for IPC on non-posix operating systems

### DIFF
--- a/pelican_katex/rendering.py
+++ b/pelican_katex/rendering.py
@@ -73,7 +73,7 @@ class RenderServer:
 
         # Start the server process
         cmd = cls.build_command(socket_path)
-        process = Popen(cmd, stdin=PIPE, stdout=PIPE)
+        process = Popen(cmd, stdin=PIPE, stdout=PIPE, cwd=rundir)
 
         # Wait for the server to come up and create the socket. Is there a
         # better way to do this?


### PR DESCRIPTION
This should make it work on Windows. However, a quick test from my side showed that the TCP connection is significantly slower than a unix socket even though the connection is through the local network interface. Re-rendering my page after a change with `pelican -rl` was 0.9 seconds over a network connection and 0.2 seconds through a domain socket.

@MoritzBrueckner Can you try this pull request on Windows?